### PR TITLE
Canceling dragging a tab from lost capture

### DIFF
--- a/AppDock/src/DockWin.h
+++ b/AppDock/src/DockWin.h
@@ -489,6 +489,14 @@ public:
 		this->layout.RebuildSashes(this->lprops);
 	}
 
+	void DelegateFinishMouseDrag()
+	{
+		// We could just make FinishMouseDrag() public, the only advantage this
+		// gives us is that we have a bottleneck of where all outside code
+		// is calling FinishMouseDrag().
+		this->FinishMouseDrag();
+	}
+
 	/// <summary>
 	/// Called to handle when a node is removed. This includes,
 	/// * When the Window for a node is closed.

--- a/AppDock/src/Layout/TabBar.cpp
+++ b/AppDock/src/Layout/TabBar.cpp
@@ -544,7 +544,10 @@ void TabBar::OnMouseChanged(wxMouseCaptureChangedEvent& evt)
 	if(this->owner->dragggingMgr != nullptr)
 	{ 
 		if(!this->owner->dragggingMgr->dragFlaggedAsFinished)
+		{ 
 			this->owner->dragggingMgr->CancelTabDragging(true);
+			this->owner->DelegateFinishMouseDrag();
+		}
 	}
 }
 


### PR DESCRIPTION
A tab being dragged wouldn't correctly clean up when cancelling the drag.